### PR TITLE
Bound message and saga payloads captured to Serilog

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,57 @@ HeaderAppender.Exclude("HeaderA", "HeaderB", "HeaderC");
 `Exclude` must be called during application startup, **before** the endpoint is started. Once the endpoint has started the exclude set is frozen and any subsequent call to `Exclude` throws `InvalidOperationException`. This makes the set effectively immutable for the lifetime of the endpoint and eliminates any race between configuration and the running pipeline.
 
 
+### Capture limits
+
+Saga tracing, message tracing, and exception enrichment capture the saga entity and the message body with destructuring enabled, so the full object graph is written into the log event. If one of those objects holds an unbounded collection or an oversized string, the resulting event can exceed the size limit of a sink. Sinks reject an oversized event whole, so a single large property discards the entire audit record, including the `SagaId`, `MessageId`, and timings needed to work out what happened. Whether a given saga or message will cross that threshold is not visible from the code, and typically only shows up under production data.
+
+To prevent that, captured payloads are bounded by default:
+
+| Limit | Default | Effect |
+| --- | --- | --- |
+| `MaxCollectionCount` | 100 | Items kept from any one collection or dictionary |
+| `MaxStringLength` | 8192 | Characters kept from any one string |
+| `MaxNodes` | 1000 | Values captured from a single payload |
+
+Clipping is never silent. Clipped values carry an inline `[truncated]` marker reporting how much was dropped, and the event gets a `SerilogTruncated` property set to `true`, so clipped events can be queried and alerted on:
+
+```
+SerilogTruncated = true
+```
+
+The limits can be changed per endpoint:
+
+<!-- snippet: LimitCapture -->
+<a id='snippet-LimitCapture'></a>
+```cs
+var serilogTracing = configuration.EnableSerilogTracing(logger);
+serilogTracing.LimitCapture(
+    new(
+        maxCollectionCount: 20,
+        maxStringLength: 2048,
+        maxNodes: 500));
+```
+<sup><a href='/src/Tests/Snippets/TracingUsage.cs#L56-L65' title='Snippet source file'>snippet source</a> | <a href='#snippet-LimitCapture' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+Pass `CaptureLimits.None` to capture payloads in full, restoring the behavior of versions before these limits were introduced.
+
+Limits are applied after Serilog has captured the value, so they compose with, and never override, destructuring configured on the logger itself. Capping capture at the source avoids building the part of the graph that is then discarded, and is worth doing in addition to these limits on hot paths:
+
+<!-- snippet: LimitCaptureAtSource -->
+<a id='snippet-LimitCaptureAtSource'></a>
+```cs
+var configuration = new LoggerConfiguration();
+configuration.Destructure.ToMaximumCollectionCount(20);
+configuration.Destructure.ToMaximumStringLength(2048);
+Log.Logger = configuration.CreateLogger();
+```
+<sup><a href='/src/Tests/Snippets/TracingUsage.cs#L70-L77' title='Snippet source file'>snippet source</a> | <a href='#snippet-LimitCaptureAtSource' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+A `Destructure.ByTransforming<T>` for a known-large type is a more targeted alternative, projecting it down to the fields worth logging.
+
+
 ### Saga tracing
 
 <!-- snippet: EnableSagaTracing -->
@@ -566,14 +617,14 @@ serilogTracing.EnableMessageTracing();
 <!-- snippet: WriteStartupDiagnostics -->
 <a id='snippet-WriteStartupDiagnostics'></a>
 ```cs
-class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
+class StartupDiagnostics(IReadOnlySettings settings, ILogger logger, CaptureLimits limits) :
     FeatureStartupTask
 {
     readonly ILogger startupLogger = logger.ForContext<StartupDiagnostics>();
 
     protected override Task OnStart(IMessageSession session, Cancel cancel = default)
     {
-        var properties = BuildProperties(settings, startupLogger);
+        var properties = BuildProperties(settings, startupLogger, limits);
 
         var templateParser = new MessageTemplateParser();
         var messageTemplate = templateParser.Parse("DiagnosticEntries");
@@ -589,8 +640,10 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
 
     static IEnumerable<LogEventProperty> BuildProperties(
         IReadOnlySettings settings,
-        ILogger logger)
+        ILogger logger,
+        CaptureLimits limits)
     {
+        var anyTruncated = false;
         var entries = settings.ReadStartupDiagnosticEntries();
         foreach (var entry in entries)
         {
@@ -600,10 +653,16 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
             }
 
             var name = CleanEntry(entry.Name);
-            if (logger.BindProperty(name, entry.Data, out var property))
+            if (logger.BindProperty(name, entry.Data, limits, out var property, out var truncated))
             {
+                anyTruncated |= truncated;
                 yield return property;
             }
+        }
+
+        if (anyTruncated)
+        {
+            yield return SerilogExtensions.TruncatedProperty();
         }
     }
 
@@ -621,7 +680,7 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
         Task.CompletedTask;
 }
 ```
-<sup><a href='/src/NServiceBus.Community.Serilog/StartupDiagnostics/WriteStartupDiagnostics.cs#L1-L58' title='Snippet source file'>snippet source</a> | <a href='#snippet-WriteStartupDiagnostics' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/NServiceBus.Community.Serilog/StartupDiagnostics/WriteStartupDiagnostics.cs#L1-L66' title='Snippet source file'>snippet source</a> | <a href='#snippet-WriteStartupDiagnostics' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 
@@ -638,7 +697,7 @@ configuration.WriteTo.Seq("http://localhost:5341");
 configuration.MinimumLevel.Information();
 var tracingLog = configuration.CreateLogger();
 ```
-<sup><a href='/src/Tests/Snippets/TracingUsage.cs#L56-L64' title='Snippet source file'>snippet source</a> | <a href='#snippet-SerilogTracingSeq' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Tests/Snippets/TracingUsage.cs#L82-L90' title='Snippet source file'>snippet source</a> | <a href='#snippet-SerilogTracingSeq' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 

--- a/src/NServiceBus.Community.Serilog/CaptureLimits.cs
+++ b/src/NServiceBus.Community.Serilog/CaptureLimits.cs
@@ -1,0 +1,99 @@
+namespace NServiceBus.Serilog;
+
+/// <summary>
+/// Bounds applied to message bodies and saga entities captured as Serilog log event properties.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Message bodies and saga entities are captured with destructuring enabled, so the full object graph
+/// is written into the log event. An unbounded collection or an oversized string on one of those objects
+/// can push the resulting event past the size limit of a sink. Sinks reject an oversized event whole, so
+/// a single large property discards the entire audit record, including the message and saga identifiers
+/// needed to diagnose it.
+/// </para>
+/// <para>
+/// These limits clip the captured payload so the rest of the event survives. Clipping is never silent:
+/// clipped values carry an inline marker, and any event containing a clipped value has a
+/// <c>SerilogTruncated</c> property set to <c>true</c> so it can be queried and alerted on.
+/// </para>
+/// <para>
+/// The limits are applied after Serilog has captured the value, so they compose with, and never override,
+/// destructuring configured on the logger itself. Capping capture at the source with
+/// <c>Destructure.ToMaximumCollectionCount</c> avoids the cost of building the discarded portion of the
+/// graph, and is worth doing in addition to these limits on hot paths.
+/// </para>
+/// </remarks>
+public class CaptureLimits
+{
+    /// <summary>
+    /// The limits used when none are configured.
+    /// </summary>
+    /// <remarks>
+    /// Keeps the first 100 items of any collection, clips strings at 8192 characters, and emits at most
+    /// 1000 nodes per captured payload.
+    /// </remarks>
+    public static CaptureLimits Default { get; } = new(
+        maxCollectionCount: 100,
+        maxStringLength: 8192,
+        maxNodes: 1000);
+
+    /// <summary>
+    /// Applies no limits, capturing payloads in full.
+    /// </summary>
+    /// <remarks>
+    /// Restores the behaviour of versions prior to the introduction of <see cref="CaptureLimits"/>. An
+    /// endpoint using this is responsible for ensuring no message or saga entity can grow large enough
+    /// to be rejected by its sinks.
+    /// </remarks>
+    public static CaptureLimits None { get; } = new(
+        maxCollectionCount: int.MaxValue,
+        maxStringLength: int.MaxValue,
+        maxNodes: int.MaxValue);
+
+    /// <summary>
+    /// The maximum number of items kept from any one collection or dictionary.
+    /// </summary>
+    public int MaxCollectionCount { get; }
+
+    /// <summary>
+    /// The maximum number of characters kept from any one string value.
+    /// </summary>
+    public int MaxStringLength { get; }
+
+    /// <summary>
+    /// The maximum number of values captured from a single payload, counting every scalar, collection,
+    /// dictionary, and object in the graph.
+    /// </summary>
+    /// <remarks>
+    /// Bounds payloads that stay under <see cref="MaxCollectionCount"/> at every level but are wide
+    /// and deep enough to be large overall. Truncation markers are added on top of this budget, so a
+    /// clipped payload emits slightly more values than the budget allows.
+    /// </remarks>
+    public int MaxNodes { get; }
+
+    /// <summary>
+    /// Initializes a new <see cref="CaptureLimits"/>.
+    /// </summary>
+    /// <param name="maxCollectionCount">The maximum number of items kept from any one collection or dictionary.</param>
+    /// <param name="maxStringLength">The maximum number of characters kept from any one string value.</param>
+    /// <param name="maxNodes">The maximum number of values emitted for a single captured payload.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if any argument is less than one.</exception>
+    public CaptureLimits(
+        int maxCollectionCount = 100,
+        int maxStringLength = 8192,
+        int maxNodes = 1000)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxCollectionCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxStringLength, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxNodes, 1);
+
+        MaxCollectionCount = maxCollectionCount;
+        MaxStringLength = maxStringLength;
+        MaxNodes = maxNodes;
+    }
+
+    internal bool IsUnlimited =>
+        MaxCollectionCount == int.MaxValue &&
+        MaxStringLength == int.MaxValue &&
+        MaxNodes == int.MaxValue;
+}

--- a/src/NServiceBus.Community.Serilog/CaptureTruncator.cs
+++ b/src/NServiceBus.Community.Serilog/CaptureTruncator.cs
@@ -1,0 +1,135 @@
+namespace NServiceBus.Serilog;
+
+/// <summary>
+/// Rebuilds a captured <see cref="LogEventPropertyValue"/> graph with <see cref="CaptureLimits"/> applied.
+/// </summary>
+/// <remarks>
+/// The graph handed to this type has already been materialized by Serilog, so it is finite and acyclic.
+/// A single instance tracks one payload and is not reusable.
+/// </remarks>
+class CaptureTruncator(CaptureLimits limits)
+{
+    internal const string Marker = "[truncated]";
+
+    static ScalarValue markerValue = new(Marker);
+
+    int remainingNodes = limits.MaxNodes;
+
+    /// <summary>
+    /// Whether any value was clipped. Only meaningful after <see cref="Truncate"/> has run.
+    /// </summary>
+    public bool Truncated { get; private set; }
+
+    public LogEventPropertyValue Truncate(LogEventPropertyValue value)
+    {
+        if (remainingNodes == 0)
+        {
+            Truncated = true;
+            return markerValue;
+        }
+
+        remainingNodes--;
+
+        return value switch
+        {
+            ScalarValue scalar => TruncateScalar(scalar),
+            SequenceValue sequence => TruncateSequence(sequence),
+            StructureValue structure => TruncateStructure(structure),
+            DictionaryValue dictionary => TruncateDictionary(dictionary),
+            // Serilog allows custom LogEventPropertyValue implementations. Their contents are opaque,
+            // so pass them through rather than dropping them.
+            _ => value
+        };
+    }
+
+    LogEventPropertyValue TruncateScalar(ScalarValue scalar)
+    {
+        if (scalar.Value is not string value ||
+            value.Length <= limits.MaxStringLength)
+        {
+            return scalar;
+        }
+
+        Truncated = true;
+        var dropped = value.Length - limits.MaxStringLength;
+        return new ScalarValue($"{value[..limits.MaxStringLength]}{Marker} {dropped} more chars");
+    }
+
+    LogEventPropertyValue TruncateSequence(SequenceValue sequence)
+    {
+        var elements = sequence.Elements;
+        var keep = Math.Min(elements.Count, limits.MaxCollectionCount);
+        var truncated = new List<LogEventPropertyValue>(keep + 1);
+
+        for (var index = 0; index < keep; index++)
+        {
+            if (remainingNodes == 0)
+            {
+                AddDropped(truncated, elements.Count - index);
+                return new SequenceValue(truncated);
+            }
+
+            truncated.Add(Truncate(elements[index]));
+        }
+
+        if (keep < elements.Count)
+        {
+            AddDropped(truncated, elements.Count - keep);
+        }
+
+        return new SequenceValue(truncated);
+    }
+
+    LogEventPropertyValue TruncateStructure(StructureValue structure)
+    {
+        var properties = structure.Properties;
+        var truncated = new List<LogEventProperty>(properties.Count);
+
+        foreach (var property in properties)
+        {
+            if (remainingNodes == 0)
+            {
+                Truncated = true;
+                break;
+            }
+
+            truncated.Add(new(property.Name, Truncate(property.Value)));
+        }
+
+        return new StructureValue(truncated, structure.TypeTag);
+    }
+
+    LogEventPropertyValue TruncateDictionary(DictionaryValue dictionary)
+    {
+        var elements = dictionary.Elements;
+        var keep = Math.Min(elements.Count, limits.MaxCollectionCount);
+        var truncated = new List<KeyValuePair<ScalarValue, LogEventPropertyValue>>(keep + 1);
+
+        var kept = 0;
+        foreach (var element in elements)
+        {
+            if (kept == keep ||
+                remainingNodes == 0)
+            {
+                break;
+            }
+
+            truncated.Add(new(element.Key, Truncate(element.Value)));
+            kept++;
+        }
+
+        if (kept < elements.Count)
+        {
+            Truncated = true;
+            truncated.Add(new(markerValue, new ScalarValue($"{elements.Count - kept} more entries")));
+        }
+
+        return new DictionaryValue(truncated);
+    }
+
+    void AddDropped(List<LogEventPropertyValue> truncated, int dropped)
+    {
+        Truncated = true;
+        truncated.Add(new ScalarValue($"{Marker} {dropped} more items"));
+    }
+}

--- a/src/NServiceBus.Community.Serilog/ExceptionEnricher.cs
+++ b/src/NServiceBus.Community.Serilog/ExceptionEnricher.cs
@@ -1,4 +1,4 @@
-﻿class ExceptionEnricher(ConvertHeader? header) :
+﻿class ExceptionEnricher(ConvertHeader? header, CaptureLimits limits) :
     ILogEventEnricher
 {
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
@@ -46,6 +46,36 @@
             logEvent.AddPropertyIfAbsent(new("HandlerType", new ScalarValue(handlerType)));
         }
 
+        AddLogState(exception, logEvent, propertyFactory);
+    }
+
+    void AddIncomingMessage(LogEvent logEvent, ILogEventPropertyFactory propertyFactory, object incomingMessage)
+    {
+        var property = propertyFactory.CreateProperty(
+            "IncomingMessage",
+            incomingMessage,
+            destructureObjects: true);
+
+        if (limits.IsUnlimited)
+        {
+            logEvent.AddPropertyIfAbsent(property);
+            return;
+        }
+
+        var truncator = new CaptureTruncator(limits);
+        var clipped = truncator.Truncate(property.Value);
+        if (!truncator.Truncated)
+        {
+            logEvent.AddPropertyIfAbsent(property);
+            return;
+        }
+
+        logEvent.AddPropertyIfAbsent(new("IncomingMessage", clipped));
+        logEvent.AddPropertyIfAbsent(SerilogExtensions.TruncatedProperty());
+    }
+
+    void AddLogState(Exception exception, LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
         if (exception.TryReadData("ExceptionLogState", out ExceptionLogState logState))
         {
             logEvent.AddPropertyIfAbsent(logState.ProcessingEndpoint);
@@ -63,11 +93,7 @@
 
             if (logState.IncomingMessage is not null)
             {
-                var messageProperty = propertyFactory.CreateProperty(
-                    "IncomingMessage",
-                    logState.IncomingMessage,
-                    destructureObjects: true);
-                logEvent.AddPropertyIfAbsent(messageProperty);
+                AddIncomingMessage(logEvent, propertyFactory, logState.IncomingMessage);
             }
 
             foreach (var property in HeaderAppender.BuildHeaders(logState.IncomingHeaders, header))

--- a/src/NServiceBus.Community.Serilog/MessageAudit/LogIncomingBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/MessageAudit/LogIncomingBehavior.cs
@@ -2,10 +2,14 @@
     Behavior<IIncomingLogicalMessageContext>
 {
     ConvertHeader convertHeader;
+    CaptureLimits limits;
     static MessageTemplate messageTemplate;
 
-    internal LogIncomingBehavior(ConvertHeader convertHeader) =>
+    internal LogIncomingBehavior(ConvertHeader convertHeader, CaptureLimits limits)
+    {
         this.convertHeader = convertHeader;
+        this.limits = limits;
+    }
 
     static LogIncomingBehavior()
     {
@@ -18,12 +22,12 @@
     public class Registration :
         RegisterStep
     {
-        public Registration(ConvertHeader convertHeader) :
+        public Registration(ConvertHeader convertHeader, CaptureLimits limits) :
             base(
                 stepId: Name,
                 behavior: typeof(LogIncomingBehavior),
                 description: "Logs incoming messages",
-                factoryMethod: _ => new LogIncomingBehavior(convertHeader))
+                factoryMethod: _ => new LogIncomingBehavior(convertHeader, limits))
         {
             InsertBefore("MutateIncomingMessages");
             InsertAfter(IncomingLogicalBehavior.Name);
@@ -60,9 +64,13 @@
                 new("ElapsedTime", new ScalarValue(elapsed.TotalSeconds))
             };
 
-            if (logger.BindProperty("IncomingMessage", message.Instance, out var property))
+            if (logger.BindProperty("IncomingMessage", message.Instance, limits, out var property, out var truncated))
             {
                 properties.Add(property);
+                if (truncated)
+                {
+                    properties.Add(SerilogExtensions.TruncatedProperty());
+                }
             }
 
             if (sagaStateChanges.Value.Length > 0)

--- a/src/NServiceBus.Community.Serilog/MessageAudit/LogOutgoingBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/MessageAudit/LogOutgoingBehavior.cs
@@ -2,10 +2,14 @@
     Behavior<IOutgoingPhysicalMessageContext>
 {
     ConvertHeader convertHeader;
+    CaptureLimits limits;
     static MessageTemplate messageTemplate;
 
-    LogOutgoingBehavior(ConvertHeader convertHeader) =>
+    LogOutgoingBehavior(ConvertHeader convertHeader, CaptureLimits limits)
+    {
         this.convertHeader = convertHeader;
+        this.limits = limits;
+    }
 
     static LogOutgoingBehavior()
     {
@@ -31,9 +35,13 @@
     {
         var properties = new List<LogEventProperty>();
 
-        if (logger.BindProperty("OutgoingMessage", message, out var messageProperty))
+        if (logger.BindProperty("OutgoingMessage", message, limits, out var messageProperty, out var truncated))
         {
             properties.Add(messageProperty);
+            if (truncated)
+            {
+                properties.Add(SerilogExtensions.TruncatedProperty());
+            }
         }
 
         var addresses = context.UnicastAddresses();
@@ -54,10 +62,10 @@
         logger.WriteInfo(messageTemplate, properties);
     }
 
-    public class Registration(ConvertHeader convertHeader) :
+    public class Registration(ConvertHeader convertHeader, CaptureLimits limits) :
         RegisterStep(
             stepId: $"Serilog{nameof(LogOutgoingBehavior)}",
             behavior: typeof(LogOutgoingBehavior),
             description: "Logs outgoing messages",
-            factoryMethod: _ => new LogOutgoingBehavior(convertHeader));
+            factoryMethod: _ => new LogOutgoingBehavior(convertHeader, limits));
 }

--- a/src/NServiceBus.Community.Serilog/MessageAudit/MessageTracingFeature.cs
+++ b/src/NServiceBus.Community.Serilog/MessageAudit/MessageTracingFeature.cs
@@ -8,7 +8,7 @@
     {
         var settings = context.Settings.TracingSettings();
         var pipeline = context.Pipeline;
-        pipeline.Register(new LogIncomingBehavior.Registration(settings.convertHeader));
-        pipeline.Register(new LogOutgoingBehavior.Registration(settings.convertHeader));
+        pipeline.Register(new LogIncomingBehavior.Registration(settings.convertHeader, settings.captureLimits));
+        pipeline.Register(new LogOutgoingBehavior.Registration(settings.convertHeader, settings.captureLimits));
     }
 }

--- a/src/NServiceBus.Community.Serilog/SagaAudit/CaptureSagaStateBehavior.cs
+++ b/src/NServiceBus.Community.Serilog/SagaAudit/CaptureSagaStateBehavior.cs
@@ -1,4 +1,4 @@
-﻿class CaptureSagaStateBehavior :
+﻿class CaptureSagaStateBehavior(CaptureLimits limits) :
     Behavior<IInvokeHandlerContext>
 {
     static MessageTemplate messageTemplate;
@@ -75,21 +75,27 @@
 
         AddInitiator(context, messageId, properties);
 
-        AddResultingMessages(sagaAudit, logger, properties);
+        var truncated = AddResultingMessages(sagaAudit, logger, properties);
 
-        AddEntity(logger, saga, properties);
+        truncated |= AddEntity(logger, saga, properties);
+
+        if (truncated)
+        {
+            properties.Add(SerilogExtensions.TruncatedProperty());
+        }
 
         logger.WriteInfo(messageTemplate, properties);
     }
 
-    static void AddEntity(ILogger logger, Saga saga, List<LogEventProperty> properties)
+    bool AddEntity(ILogger logger, Saga saga, List<LogEventProperty> properties)
     {
-        if (!logger.BindProperty("Entity", saga.Entity, out var sagaEntityProperty))
+        if (!logger.BindProperty("Entity", saga.Entity, limits, out var sagaEntityProperty, out var truncated))
         {
-            return;
+            return false;
         }
 
         properties.Add(sagaEntityProperty);
+        return truncated;
     }
 
     static void AddInitiator(IInvokeHandlerContext context, string messageId, List<LogEventProperty> properties)
@@ -122,20 +128,21 @@
         properties.Add(new("Initiator", new DictionaryValue(initiator)));
     }
 
-    static void AddResultingMessages(SagaUpdatedMessage sagaAudit, ILogger logger, List<LogEventProperty> properties)
+    bool AddResultingMessages(SagaUpdatedMessage sagaAudit, ILogger logger, List<LogEventProperty> properties)
     {
         var resultingMessages = sagaAudit.ResultingMessages;
         if (resultingMessages.Count == 0)
         {
-            return;
+            return false;
         }
 
-        if (!logger.BindProperty("ResultingMessages", resultingMessages, out var resultingMessagesProperty))
+        if (!logger.BindProperty("ResultingMessages", resultingMessages, limits, out var resultingMessagesProperty, out var truncated))
         {
-            return;
+            return false;
         }
 
         properties.Add(resultingMessagesProperty);
+        return truncated;
     }
 
     static void AssignSagaStateChangeCausedByMessage(IInvokeHandlerContext context, bool isNew, bool isCompleted, Guid sagaId)
@@ -163,12 +170,12 @@
     public class Registration :
         RegisterStep
     {
-        public Registration() :
+        public Registration(CaptureLimits limits) :
             base(
                 stepId: $"Serilog{nameof(CaptureSagaStateBehavior)}",
                 behavior: typeof(CaptureSagaStateBehavior),
                 description: "Records saga state changes",
-                factoryMethod: _ => new CaptureSagaStateBehavior()) =>
+                factoryMethod: _ => new CaptureSagaStateBehavior(limits)) =>
             InsertBefore("InvokeSaga");
     }
 }

--- a/src/NServiceBus.Community.Serilog/SagaAudit/SagaTracingFeature.cs
+++ b/src/NServiceBus.Community.Serilog/SagaAudit/SagaTracingFeature.cs
@@ -9,8 +9,9 @@
 
     protected override void Setup(FeatureConfigurationContext context)
     {
+        var settings = context.Settings.TracingSettings();
         var pipeline = context.Pipeline;
-        pipeline.Register(new CaptureSagaStateBehavior.Registration());
+        pipeline.Register(new CaptureSagaStateBehavior.Registration(settings.captureLimits));
         pipeline.Register(new CaptureSagaResultingBehavior.Registration());
     }
 }

--- a/src/NServiceBus.Community.Serilog/SerilogExtensions.cs
+++ b/src/NServiceBus.Community.Serilog/SerilogExtensions.cs
@@ -1,11 +1,53 @@
 ﻿static class SerilogExtensions
 {
+    /// <summary>
+    /// The property added to any log event that carries a clipped payload.
+    /// </summary>
+    public const string TruncatedPropertyName = "SerilogTruncated";
+
+    static LogEventProperty truncatedProperty = new(TruncatedPropertyName, new ScalarValue(true));
+
+    /// <summary>
+    /// Captures a value with destructuring enabled and the supplied limits applied.
+    /// </summary>
+    /// <remarks>
+    /// The <c>truncated</c> output reports whether the captured value was clipped. Callers must add
+    /// <see cref="TruncatedProperty"/> to the event when it is set, so clipping is queryable rather
+    /// than silent.
+    /// </remarks>
     public static bool BindProperty(
         this ILogger logger,
         string name,
         object value,
-        [NotNullWhen(true)] out LogEventProperty? property) =>
-        logger.BindProperty(name, value, true, out property);
+        CaptureLimits limits,
+        [NotNullWhen(true)] out LogEventProperty? property,
+        out bool truncated)
+    {
+        truncated = false;
+
+        if (!logger.BindProperty(name, value, true, out var bound))
+        {
+            property = null;
+            return false;
+        }
+
+        if (limits.IsUnlimited)
+        {
+            property = bound;
+            return true;
+        }
+
+        var truncator = new CaptureTruncator(limits);
+        var clipped = truncator.Truncate(bound.Value);
+        truncated = truncator.Truncated;
+        property = truncated ? new(name, clipped) : bound;
+        return true;
+    }
+
+    /// <summary>
+    /// Flags an event as carrying a clipped payload.
+    /// </summary>
+    public static LogEventProperty TruncatedProperty() => truncatedProperty;
 
     public static void WriteInfo(
         this ILogger logger,

--- a/src/NServiceBus.Community.Serilog/SerilogTracingExtensions.cs
+++ b/src/NServiceBus.Community.Serilog/SerilogTracingExtensions.cs
@@ -14,9 +14,12 @@ public static partial class SerilogTracingExtensions
     /// <summary>
     /// Take NSB specific info from <see cref="Exception.Data" /> and promotes it to Serilog properties.
     /// </summary>
-    public static LoggerEnrichmentConfiguration WithNsbExceptionDetails(this LoggerEnrichmentConfiguration configuration, ConvertHeader? convertHeader = null)
+    public static LoggerEnrichmentConfiguration WithNsbExceptionDetails(
+        this LoggerEnrichmentConfiguration configuration,
+        ConvertHeader? convertHeader = null,
+        CaptureLimits? captureLimits = null)
     {
-        configuration.With(new ExceptionEnricher(convertHeader));
+        configuration.With(new ExceptionEnricher(convertHeader, captureLimits ?? CaptureLimits.Default));
         return configuration;
     }
 

--- a/src/NServiceBus.Community.Serilog/SerilogTracingSettings.cs
+++ b/src/NServiceBus.Community.Serilog/SerilogTracingSettings.cs
@@ -8,6 +8,7 @@ public class SerilogTracingSettings
     internal ILogger Logger;
     EndpointConfiguration configuration;
     internal ConvertHeader convertHeader = (_, _) => null;
+    internal CaptureLimits captureLimits = CaptureLimits.Default;
 
     internal SerilogTracingSettings(ILogger logger, EndpointConfiguration configuration)
     {
@@ -32,4 +33,14 @@ public class SerilogTracingSettings
     /// </summary>
     public void EnableMessageTracing() =>
         configuration.EnableFeature<MessageTracingFeature>();
+
+    /// <summary>
+    /// Bound the size of message bodies and saga entities captured as log event properties.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <see cref="CaptureLimits.Default"/>. Pass <see cref="CaptureLimits.None"/> to capture
+    /// payloads in full. See <see cref="CaptureLimits"/> for why the limits exist.
+    /// </remarks>
+    public void LimitCapture(CaptureLimits limits) =>
+        captureLimits = limits;
 }

--- a/src/NServiceBus.Community.Serilog/StartupDiagnostics/WriteStartupDiagnostics.cs
+++ b/src/NServiceBus.Community.Serilog/StartupDiagnostics/WriteStartupDiagnostics.cs
@@ -1,13 +1,13 @@
 #region WriteStartupDiagnostics
 
-class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
+class StartupDiagnostics(IReadOnlySettings settings, ILogger logger, CaptureLimits limits) :
     FeatureStartupTask
 {
     readonly ILogger startupLogger = logger.ForContext<StartupDiagnostics>();
 
     protected override Task OnStart(IMessageSession session, Cancel cancel = default)
     {
-        var properties = BuildProperties(settings, startupLogger);
+        var properties = BuildProperties(settings, startupLogger, limits);
 
         var templateParser = new MessageTemplateParser();
         var messageTemplate = templateParser.Parse("DiagnosticEntries");
@@ -23,8 +23,10 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
 
     static IEnumerable<LogEventProperty> BuildProperties(
         IReadOnlySettings settings,
-        ILogger logger)
+        ILogger logger,
+        CaptureLimits limits)
     {
+        var anyTruncated = false;
         var entries = settings.ReadStartupDiagnosticEntries();
         foreach (var entry in entries)
         {
@@ -34,10 +36,16 @@ class StartupDiagnostics(IReadOnlySettings settings, ILogger logger) :
             }
 
             var name = CleanEntry(entry.Name);
-            if (logger.BindProperty(name, entry.Data, out var property))
+            if (logger.BindProperty(name, entry.Data, limits, out var property, out var truncated))
             {
+                anyTruncated |= truncated;
                 yield return property;
             }
+        }
+
+        if (anyTruncated)
+        {
+            yield return SerilogExtensions.TruncatedProperty();
         }
     }
 

--- a/src/NServiceBus.Community.Serilog/TracingFeature.cs
+++ b/src/NServiceBus.Community.Serilog/TracingFeature.cs
@@ -16,6 +16,6 @@
         pipeline.Register(new HandlerContextBehavior.Registration());
         pipeline.Register(new MessageContextBehavior.Registration());
         pipeline.Register(new OutgoingBehavior.Registration(logBuilder));
-        context.RegisterStartupTask(new StartupDiagnostics(context.Settings, logBuilder.Logger));
+        context.RegisterStartupTask(new StartupDiagnostics(context.Settings, logBuilder.Logger, settings.captureLimits));
     }
 }

--- a/src/Tests/CaptureTruncatorTests.cs
+++ b/src/Tests/CaptureTruncatorTests.cs
@@ -1,0 +1,214 @@
+public class CaptureTruncatorTests
+{
+    [Test]
+    public async Task LeavesSmallPayloadUntouched()
+    {
+        var (property, truncated) = Bind(
+            new
+            {
+                Name = "small",
+                Items = new[] { 1, 2, 3 }
+            },
+            new CaptureLimits());
+
+        await Assert.That(truncated).IsFalse();
+        await Assert.That(Render(property)).DoesNotContain(CaptureTruncator.Marker);
+    }
+
+    [Test]
+    public async Task ClipsCollectionAndReportsDroppedCount()
+    {
+        var (property, truncated) = Bind(
+            new
+            {
+                Items = Enumerable.Range(0, 50).ToArray()
+            },
+            new CaptureLimits(maxCollectionCount: 10));
+
+        await Assert.That(truncated).IsTrue();
+
+        var items = (SequenceValue) ((StructureValue) property.Value).Properties.Single().Value;
+        await Assert.That(items.Elements.Count).IsEqualTo(11);
+        await Assert.That(Scalar(items.Elements[10])).IsEqualTo($"{CaptureTruncator.Marker} 40 more items");
+    }
+
+    [Test]
+    public async Task KeepsTheFirstItemsOfAClippedCollection()
+    {
+        var (property, _) = Bind(
+            new
+            {
+                Items = Enumerable.Range(0, 50).ToArray()
+            },
+            new CaptureLimits(maxCollectionCount: 3));
+
+        var items = (SequenceValue) ((StructureValue) property.Value).Properties.Single().Value;
+        var kept = items.Elements
+            .Take(3)
+            .Select(_ => (int) ((ScalarValue) _).Value!);
+        await Assert.That(kept).IsEquivalentTo([0, 1, 2]);
+    }
+
+    [Test]
+    public async Task ClipsLongString()
+    {
+        var (property, truncated) = Bind(
+            new
+            {
+                Text = new string('x', 100)
+            },
+            new CaptureLimits(maxStringLength: 10));
+
+        await Assert.That(truncated).IsTrue();
+
+        var text = Scalar(((StructureValue) property.Value).Properties.Single().Value);
+        await Assert.That(text).IsEqualTo($"xxxxxxxxxx{CaptureTruncator.Marker} 90 more chars");
+    }
+
+    [Test]
+    public async Task ClipsDictionary()
+    {
+        var (property, truncated) = Bind(
+            Enumerable.Range(0, 20).ToDictionary(_ => $"key{_}", _ => _),
+            new CaptureLimits(maxCollectionCount: 5));
+
+        await Assert.That(truncated).IsTrue();
+
+        var dictionary = (DictionaryValue) property.Value;
+        await Assert.That(dictionary.Elements.Count).IsEqualTo(6);
+        await Assert.That(Scalar(dictionary.Elements[new(CaptureTruncator.Marker)])).IsEqualTo("15 more entries");
+    }
+
+    [Test]
+    public async Task NodeBudgetBoundsWideAndDeepPayloads()
+    {
+        // Every collection stays under MaxCollectionCount, so only the node budget can bound this.
+        var (property, truncated) = Bind(
+            new
+            {
+                Outer = Enumerable
+                    .Range(0, 5)
+                    .Select(_ => new
+                    {
+                        Inner = Enumerable.Range(0, 5).ToArray()
+                    })
+                    .ToArray()
+            },
+            new CaptureLimits(maxCollectionCount: 10, maxNodes: 12));
+
+        await Assert.That(truncated).IsTrue();
+
+        // MaxNodes bounds values captured from the payload. Markers are added on top of that
+        // budget so truncation is always visible, so they are excluded from the count.
+        var captured = CountNodes(property.Value) - CountMarkers(property.Value);
+        await Assert.That(captured).IsLessThanOrEqualTo(12);
+    }
+
+    [Test]
+    public async Task PreservesTypeTag()
+    {
+        var (property, _) = Bind(
+            new Tagged
+            {
+                Items = Enumerable.Range(0, 50).ToArray()
+            },
+            new CaptureLimits(maxCollectionCount: 2));
+
+        await Assert.That(((StructureValue) property.Value).TypeTag).IsEqualTo(nameof(Tagged));
+    }
+
+    [Test]
+    public async Task NoneCapturesInFull()
+    {
+        var (property, truncated) = Bind(
+            new
+            {
+                Items = Enumerable.Range(0, 5000).ToArray()
+            },
+            CaptureLimits.None);
+
+        await Assert.That(truncated).IsFalse();
+
+        var items = (SequenceValue) ((StructureValue) property.Value).Properties.Single().Value;
+        await Assert.That(items.Elements.Count).IsEqualTo(5000);
+    }
+
+    [Test]
+    public async Task DefaultLimitsClipAnUnboundedSagaEntity()
+    {
+        // Mirrors the failure this guards against: a saga entity accumulating an unbounded
+        // collection until the whole event is rejected by the sink.
+        var entity = new
+        {
+            Key = Guid.NewGuid(),
+            Entries = Enumerable
+                .Range(0, 800)
+                .Select(_ => new
+                {
+                    EntityId = Guid.NewGuid(),
+                    EntityType = "Indicator",
+                    Action = "Deleted",
+                    Title = $"E2E-Indicator-{_}"
+                })
+                .ToArray()
+        };
+
+        var (property, truncated) = Bind(entity, CaptureLimits.Default);
+
+        await Assert.That(truncated).IsTrue();
+        await Assert.That(Render(property).Length).IsLessThan(262144);
+    }
+
+    [Test]
+    public void RejectsNonPositiveLimits()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CaptureLimits(maxCollectionCount: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CaptureLimits(maxStringLength: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CaptureLimits(maxNodes: 0));
+    }
+
+    static (LogEventProperty Property, bool Truncated) Bind(object value, CaptureLimits limits)
+    {
+        var logger = new LoggerConfiguration().CreateLogger();
+        if (!logger.BindProperty("Payload", value, limits, out var property, out var truncated))
+        {
+            throw new("Failed to bind the payload.");
+        }
+
+        return (property, truncated);
+    }
+
+    static string Scalar(LogEventPropertyValue value) =>
+        (string) ((ScalarValue) value).Value!;
+
+    static string Render(LogEventProperty property)
+    {
+        var writer = new StringWriter();
+        property.Value.Render(writer);
+        return writer.ToString();
+    }
+
+    static int CountMarkers(LogEventPropertyValue value) =>
+        value switch
+        {
+            ScalarValue scalar => scalar.Value is string text && text.Contains(CaptureTruncator.Marker) ? 1 : 0,
+            SequenceValue sequence => sequence.Elements.Sum(CountMarkers),
+            StructureValue structure => structure.Properties.Sum(_ => CountMarkers(_.Value)),
+            DictionaryValue dictionary => dictionary.Elements.Sum(_ => CountMarkers(_.Value)),
+            _ => 0
+        };
+
+    static int CountNodes(LogEventPropertyValue value) =>
+        value switch
+        {
+            SequenceValue sequence => 1 + sequence.Elements.Sum(CountNodes),
+            StructureValue structure => 1 + structure.Properties.Sum(_ => CountNodes(_.Value)),
+            DictionaryValue dictionary => 1 + dictionary.Elements.Sum(_ => CountNodes(_.Value)),
+            _ => 1
+        };
+
+    class Tagged
+    {
+        public int[] Items { get; init; } = [];
+    }
+}

--- a/src/Tests/DelegatingSink.cs
+++ b/src/Tests/DelegatingSink.cs
@@ -1,0 +1,5 @@
+class DelegatingSink(Action<LogEvent> handler) :
+    ILogEventSink
+{
+    public void Emit(LogEvent logEvent) => handler(logEvent);
+}

--- a/src/Tests/ExceptionEnricherTests.cs
+++ b/src/Tests/ExceptionEnricherTests.cs
@@ -6,7 +6,7 @@ public class ExceptionEnricherTests
         var captured = new List<LogEvent>();
         var logger = new LoggerConfiguration()
             .Destructure.ByTransforming<SecretMessage>(_ => new { Redacted = true })
-            .Enrich.With(new ExceptionEnricher(header: null))
+            .Enrich.With(new ExceptionEnricher(header: null, limits: CaptureLimits.Default))
             .WriteTo.Sink(new DelegatingSink(captured.Add))
             .CreateLogger();
 
@@ -32,10 +32,5 @@ public class ExceptionEnricherTests
     class SecretMessage(string token)
     {
         public string Token => token;
-    }
-
-    class DelegatingSink(Action<LogEvent> handler) : ILogEventSink
-    {
-        public void Emit(LogEvent logEvent) => handler(logEvent);
     }
 }

--- a/src/Tests/LogIncomingBehaviorTests.cs
+++ b/src/Tests/LogIncomingBehaviorTests.cs
@@ -47,6 +47,68 @@ public class LogIncomingBehaviorTests
         await Verify(context);
     }
 
+    [Test]
+    public async Task ClipsOversizedMessageAndFlagsTheEvent()
+    {
+        var captured = new List<LogEvent>();
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(new DelegatingSink(captured.Add))
+            .CreateLogger();
+
+        var context = new TestableIncomingLogicalMessageContext
+        {
+            Message = new(
+                new(typeof(BigMessage)),
+                new BigMessage
+                {
+                    Items = Enumerable.Range(0, 500).ToArray()
+                })
+        };
+        context.Extensions.Set((ILogger) logger);
+
+        var behavior = new LogIncomingBehavior(
+            convertHeader: (_, _) => null,
+            limits: new(maxCollectionCount: 10));
+        await behavior.Invoke(context, () => Task.CompletedTask);
+
+        var logEvent = captured.Single();
+
+        await Assert.That(logEvent.Properties.ContainsKey(SerilogExtensions.TruncatedPropertyName)).IsTrue();
+
+        var message = (StructureValue) logEvent.Properties["IncomingMessage"];
+        var items = (SequenceValue) message.Properties.Single(_ => _.Name == nameof(BigMessage.Items)).Value;
+
+        // 10 kept, plus the marker reporting the 490 dropped.
+        await Assert.That(items.Elements.Count).IsEqualTo(11);
+        await Assert.That((string) ((ScalarValue) items.Elements[10]).Value!)
+            .IsEqualTo($"{CaptureTruncator.Marker} 490 more items");
+
+        // The rest of the audit record survives, which is the whole point.
+        await Assert.That(logEvent.Properties.ContainsKey("StartTime")).IsTrue();
+        await Assert.That(logEvent.Properties.ContainsKey("ElapsedTime")).IsTrue();
+    }
+
+    [Test]
+    public async Task DoesNotFlagEventWhenNothingIsClipped()
+    {
+        var captured = new List<LogEvent>();
+        var logger = new LoggerConfiguration()
+            .WriteTo.Sink(new DelegatingSink(captured.Add))
+            .CreateLogger();
+
+        var context = BuildContext();
+        context.Extensions.Set((ILogger) logger);
+
+        await BuildBehavior().Invoke(context, () => Task.CompletedTask);
+
+        await Assert.That(captured.Single().Properties.ContainsKey(SerilogExtensions.TruncatedPropertyName)).IsFalse();
+    }
+
+    class BigMessage
+    {
+        public int[] Items { get; init; } = [];
+    }
+
     static TestableIncomingLogicalMessageContext BuildContext() =>
         new()
         {
@@ -54,7 +116,7 @@ public class LogIncomingBehaviorTests
         };
 
     static LogIncomingBehavior BuildBehavior() =>
-        new(convertHeader: (_, _) => null);
+        new(convertHeader: (_, _) => null, limits: CaptureLimits.Default);
 
     class Message1;
 }

--- a/src/Tests/Snippets/TracingUsage.cs
+++ b/src/Tests/Snippets/TracingUsage.cs
@@ -51,6 +51,32 @@ class TracingUsage
         #endregion
     }
 
+    static void LimitCapture(EndpointConfiguration configuration, ILogger logger)
+    {
+        #region LimitCapture
+
+        var serilogTracing = configuration.EnableSerilogTracing(logger);
+        serilogTracing.LimitCapture(
+            new(
+                maxCollectionCount: 20,
+                maxStringLength: 2048,
+                maxNodes: 500));
+
+        #endregion
+    }
+
+    static void LimitCaptureAtSource()
+    {
+        #region LimitCaptureAtSource
+
+        var configuration = new LoggerConfiguration();
+        configuration.Destructure.ToMaximumCollectionCount(20);
+        configuration.Destructure.ToMaximumStringLength(2048);
+        Log.Logger = configuration.CreateLogger();
+
+        #endregion
+    }
+
     static void Seq()
     {
         #region SerilogTracingSeq


### PR DESCRIPTION
Saga entities and message bodies are captured with destructuring enabled, so the full object graph is written into the log event. An unbounded collection or oversized string on one of those objects can push the event past the size limit of a sink, and sinks reject an oversized event whole. A single large property therefore discards the entire audit record, including the SagaId, MessageId and timings needed to diagnose it. Whether a saga or message will cross that threshold is not visible from the code and typically only surfaces under production data.

Add CaptureLimits, applied by default, bounding collection count, string length, and total nodes captured per payload. Applied at every destructuring site: saga Entity and ResultingMessages, incoming and outgoing message audit, startup diagnostics, and the exception enricher.

Clipping is never silent. Clipped values carry an inline [truncated] marker reporting how much was dropped, and the event gets SerilogTruncated set to true so clipped events can be queried and alerted on.

Limits are applied after Serilog has captured the value, so they compose with, and never override, destructuring configured on the logger itself.

Configurable per endpoint via SerilogTracingSettings.LimitCapture, and via a new optional parameter on WithNsbExceptionDetails for the enricher. CaptureLimits.None restores the previous unbounded behaviour.

Note this changes output for existing endpoints that emit large payloads.
