### PR TITLE
Restore pre-CaptureLimits overloads as obsolete

### DIFF
--- a/src/NServiceBus.Community.Serilog/SerilogExtensions.cs
+++ b/src/NServiceBus.Community.Serilog/SerilogExtensions.cs
@@ -8,6 +8,18 @@
     static LogEventProperty truncatedProperty = new(TruncatedPropertyName, new ScalarValue(true));
 
     /// <summary>
+    /// Captures a value with destructuring enabled and no limits applied.
+    /// </summary>
+    [Obsolete("Use the overload that takes a CaptureLimits. Pass CaptureLimits.None for the previous unbounded behavior.")]
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static bool BindProperty(
+        this ILogger logger,
+        string name,
+        object value,
+        [NotNullWhen(true)] out LogEventProperty? property) =>
+        logger.BindProperty(name, value, CaptureLimits.None, out property, out _);
+
+    /// <summary>
     /// Captures a value with destructuring enabled and the supplied limits applied.
     /// </summary>
     /// <remarks>

--- a/src/NServiceBus.Community.Serilog/SerilogTracingExtensions.cs
+++ b/src/NServiceBus.Community.Serilog/SerilogTracingExtensions.cs
@@ -14,6 +14,16 @@ public static partial class SerilogTracingExtensions
     /// <summary>
     /// Take NSB specific info from <see cref="Exception.Data" /> and promotes it to Serilog properties.
     /// </summary>
+    [Obsolete("Use the overload that takes a CaptureLimits. Pass CaptureLimits.None for the previous unbounded behavior.")]
+    [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+    public static LoggerEnrichmentConfiguration WithNsbExceptionDetails(
+        this LoggerEnrichmentConfiguration configuration,
+        ConvertHeader? convertHeader = null) =>
+        configuration.WithNsbExceptionDetails(convertHeader, CaptureLimits.None);
+
+    /// <summary>
+    /// Take NSB specific info from <see cref="Exception.Data" /> and promotes it to Serilog properties.
+    /// </summary>
     public static LoggerEnrichmentConfiguration WithNsbExceptionDetails(
         this LoggerEnrichmentConfiguration configuration,
         ConvertHeader? convertHeader = null,


### PR DESCRIPTION
e1dbf37 added a CaptureLimits parameter to WithNsbExceptionDetails and SerilogExtensions.BindProperty, which is binary breaking for existing callers.

Add back the original signatures, mark them [Obsolete], and give them [OverloadResolutionPriority(-1)] so they are never selected at compile time. They delegate with CaptureLimits.None, preserving the previous unbounded behaviour for callers that bind to them.

